### PR TITLE
Added protection for specific entities from /toolkit kill command

### DIFF
--- a/common/src/main/java/com/sunekaer/toolkit/commands/level/KillEntitiesCommand.java
+++ b/common/src/main/java/com/sunekaer/toolkit/commands/level/KillEntitiesCommand.java
@@ -4,6 +4,7 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.Codec;
+import com.sunekaer.toolkit.Toolkit;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -13,6 +14,8 @@ import net.minecraft.commands.synchronization.SuggestionProviders;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.entity.Entity;
@@ -30,6 +33,10 @@ import java.util.List;
 import java.util.function.BiPredicate;
 
 public class KillEntitiesCommand {
+    public static final TagKey<EntityType<?>> KILL_PROTECTED = TagKey.create(
+            Registries.ENTITY_TYPE,
+            ResourceLocation.fromNamespaceAndPath(Toolkit.MOD_ID, "kill_protected"));
+
     enum KillType implements StringRepresentable {
         all((p, entity) -> !(entity instanceof AbstractMinecart) && !entity.getUUID().equals(p.getUUID())),
         animals((p, entity) -> entity instanceof Animal),
@@ -83,7 +90,7 @@ public class KillEntitiesCommand {
         EntityType<?> entityType = reference.value();
 
         source.sendSuccess(() -> Component.translatable("commands.toolkit.kill.start", entityType), true);
-        var entitiesKilled = yeetEntities((player, entity) -> entity.getType().equals(entityType), level, source.getPlayerOrException());
+        var entitiesKilled = yeetEntities((player, entity) -> entity.getType().equals(entityType), level, source.getPlayerOrException(), false);
         yeetedEntitiesMessage(source, entitiesKilled, entityType.toShortString());
 
         return 0;
@@ -102,7 +109,7 @@ public class KillEntitiesCommand {
                 entitiesKilled++;
             }
         } else {
-            entitiesKilled += yeetEntities(type.checker, level, source.getPlayerOrException());
+            entitiesKilled += yeetEntities(type.checker, level, source.getPlayerOrException(), true);
         }
 
         yeetedEntitiesMessage(source, entitiesKilled, typeName);
@@ -118,7 +125,7 @@ public class KillEntitiesCommand {
         }
     }
 
-    private static int yeetEntities(BiPredicate<Player, Entity> tester, ServerLevel level, Player player) {
+    private static int yeetEntities(BiPredicate<Player, Entity> tester, ServerLevel level, Player player, boolean respectProtection) {
         int entitiesKilled = 0;
         Iterable<Entity> entities = level.getAllEntities();
 
@@ -128,6 +135,10 @@ public class KillEntitiesCommand {
 
         for (Entity entity : entityList) {
             if (entity == null) {
+                continue;
+            }
+
+            if (respectProtection && entity.getType().is(KILL_PROTECTED)) {
                 continue;
             }
 

--- a/common/src/main/resources/data/toolkit/tags/entity_type/kill_protected.json
+++ b/common/src/main/resources/data/toolkit/tags/entity_type/kill_protected.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    { "id": "aeronautics:propeller_bearing_contraption", "required": false }
+  ]
+}

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -9,6 +9,9 @@ architectury {
 
 repositories {
     maven {
+        url "https://maven.neoforged.net/releases"
+    }
+    maven {
         url "https://maven.saps.dev/mirror"
     }
 }


### PR DESCRIPTION
Added a new `toolkit:kill_protected` entity type tag.

Entities listed in this tag will be ignored by general `/toolkit kill` commands, preventing their accidental destruction. This protection does not apply when killing a specific entity type, as that implies explicit intent.
